### PR TITLE
Settings for locked down firewall setups e.g. that block outgoing by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # Fork Description
 
-This is a fork of the pia manual connections script which enables running the PIA vpn in a docker container in addition to normal usage.
+This is a fork of the pia manual connections script with support for locked down firewall setups (e.g. that block outgoing by default).
+
+#### Other Features
+
+* Can run in a docker container
 
 ## Config
+
+Firewall Related:
+
+| ENV Var | Function |
+|-------|------|
+|```PIA_ON_DEMAND_UFW_RULES=true```|Before accessing an ip adds a firewall rule allowing outgoing access to it and then removes it afterwards. (requires ufw)|
+|```PIA_ADD_VPN_ENDPOINT_TO_UFW=true```|Adds a firewall rule allowing outgoing access the vpn endpoint (permanently).|
+|```PIA_SERVERLIST_HOST_IP="xxx.xxx.xxx.xxx"```|The ip for the serverlist host ( serverlist.piaservers.net ). When specified allows it to be accessed without having to permit DNS on the open net through the firewall.|
+
+* Caveat: If using ```PIA_ON_DEMAND_UFW_RULES=true```, backup your ufw rules first. If the script encounteres issues and somehow fails to remove the temporary rules, it may leave behind a lot of spam.
 
 Authentication:
 
@@ -14,7 +28,7 @@ Authentication:
 |```PIA_USER=p0123456```|Your username.|
 |```PIA_PASS=xxxxx```|Your password.|
 
-The following ENV vars are optional:
+Misc:
 
 | ENV Var | Function |
 |-------|------|

--- a/funcs.sh
+++ b/funcs.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright (C) 2020 Private Internet Access, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -a
+
+function on_demand_rules_cmd {
+  if [[ "$PIA_ON_DEMAND_UFW_RULES" == "true" ]]; then
+    eval "$@"
+  fi
+}
+
+function make_ufw_allow_args {
+  destination=$1
+  if [[ -z $destination ]]; then
+    1>&2 echo "${FUNCNAME[0]}: error: first param destination was empty"
+    return 1
+  fi
+  echo "allow out from any to $destination"
+}
+
+function ufw_allow {
+  destination=$1
+  if [[ -z $destination ]]; then
+    1>&2 echo "${FUNCNAME[0]}: error: first param destination was empty"
+    return 1
+  fi
+  ufw $(make_ufw_allow_args $destination)
+}
+
+function ufw_unallow {
+  destination=$1
+  if [[ -z $destination ]]; then
+    1>&2 echo "${FUNCNAME[0]}: error: first param destination was empty"
+    return 1
+  fi
+  ufw delete $(make_ufw_allow_args $destination)
+}
+
+function ufw_allow_if_requested {
+  destination=$1
+  if [[ -z $destination ]]; then
+    1>&2 echo "${FUNCNAME[0]}: error: first param destination was empty"
+    return 1
+  fi
+  on_demand_rules_cmd ufw_allow $destination
+}
+
+function ufw_unallow_if_requested {
+  destination=$1
+  if [[ -z $destination ]]; then
+    1>&2 echo "${FUNCNAME[0]}: error: first param destination was empty"
+    return 1
+  fi
+  on_demand_rules_cmd ufw_unallow $destination
+}
+
+set +a


### PR DESCRIPTION
Adds settings for locked down firewall setups e.g. that block outgoing by default.

| ENV Var | Function |
|-------|------|
|```PIA_ON_DEMAND_UFW_RULES=true```|Before accessing an ip adds a firewall rule allowing outgoing access to it and then removes it afterwards. (requires ufw)|
|```PIA_ADD_VPN_ENDPOINT_TO_UFW=true```|Adds a firewall rule allowing outgoing access the vpn endpoint (permanently).|
|```PIA_SERVERLIST_HOST_IP="xxx.xxx.xxx.xxx"```|The ip for the serverlist host ( serverlist.piaservers.net ). When specified allows it to be accessed without having to permit DNS on the open net through the firewall.|
