### PR TITLE
Run as systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is a fork of the pia manual connections script with support for locked down
 * Eternal port forwarding (requests a new port on expiration of old)
   * can run a custom command when a forwarded port is established (see ```PIA_ON_PORT_FORWARD```)
 * Writes forwarded port to file for use by other services (```/opt/piavpn-manual/pia_port```)
+* Can run as a systemd service
+  * Instructions: copy *.service file to /etc/systemd/system then customize vars prefixed with $ (e.g. $VAR)
 * Can run in a docker container
 
 ## Config
@@ -38,6 +40,7 @@ Misc:
 |```PIA_ON_PORT_FORWARD=command```|A command to be run when a forwarded port is established. The command will be called with one additional argument of the port number.|
 |```PIA_REGION=swiss```|Region to connect to. Available server region ids are listed [here](https://serverlist.piaservers.net/vpninfo/servers/v4). Example values include ```us_california```, ```ca_ontario```, and ```swiss```. If left empty, reverts to autodetecting the fastest region.|
 |```PIA_LOCAL_ROUTES=xxxxx```|Custom local routes. Many can be specified seperated by a space. (Only applies to wireguard).|
+|```PIA_WRITE_STARTUP_DONE_FILE=path```|When startup has completed successfully message "startup done" will be written to the file in the var. Can be used to manage dependencies (i.e. to launch another program when this one has completed). It is particularly useful when using port forwarding, as normally it wouldn't be clear when we have started up as the port forwarding script runs forever.|
 
 # Manual PIA VPN Connections
 

--- a/connect_to_openvpn_with_token.sh
+++ b/connect_to_openvpn_with_token.sh
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+. ./funcs.sh
+
 # This function allows you to check if the required tools have been installed.
 function check_tool() {
   cmd=$1
@@ -219,6 +221,7 @@ if [ "$PIA_PF" != true ]; then
   echo $ OVPN_SERVER_IP=\"$OVPN_SERVER_IP\" OVPN_HOSTNAME=\"$OVPN_HOSTNAME\" \
     PIA_TOKEN=\"$PIA_TOKEN\" CONNECTION_SETTINGS=\"$CONNECTION_SETTINGS\" \
     PIA_PF=true ./connect_to_openvpn_with_token.sh
+  indicate_startup_done_if_needed
   exit
 fi
 

--- a/connect_to_wireguard_with_token.sh
+++ b/connect_to_wireguard_with_token.sh
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+. ./funcs.sh
+
 # This function allows you to check if the required tools have been installed.
 function check_tool() {
   cmd=$1
@@ -151,6 +153,15 @@ if [[ -n "$PIA_LOCAL_ROUTES" ]]; then
   done
 fi
 
+echo "Waiting for WireGuard to fully initialize."
+for i in {5..1}; do
+  echo -n "$i... "
+  sleep 1
+done
+echo "done"
+echo
+echo
+
 # This section will stop the script if PIA_PF is not set to "true".
 if [ "$PIA_PF" != true ]; then
   echo
@@ -159,25 +170,18 @@ if [ "$PIA_PF" != true ]; then
   echo $ WG_SERVER_IP=10.0.0.3 WG_HOSTNAME=piaserver401 \
     PIA_TOKEN=\"\$token\" PIA_PF=true \
     ./connect_to_wireguard_with_token.sh
+  indicate_startup_done_if_needed
   exit
 fi
 
-echo -n "
-This script got started with PIA_PF=true. We will allow WireGuard to fully
-initialize and after that we will try to enable PF by running the following
-command:
+echo " 
+This script got started with PIA_PF=true.
+Starting procedure to enable port forwarding by running the following command:
 $ PIA_TOKEN=$PIA_TOKEN \\
   PF_GATEWAY=\"$(echo "$wireguard_json" | jq -r '.server_vip')\" \\
   PF_HOSTNAME=\"$WG_HOSTNAME\" \\
   ./port_forwarding.sh
-  
-Starting PF in "
-for i in {5..1}; do
-  echo -n "$i... "
-  sleep 1
-done
-echo
-echo
+"
 
 # now that we are inside the vpn, use a local ip for the meta server, it's faster and less error prone.
 export PIA_SERVER_META_IP="10.0.0.1"

--- a/funcs.sh
+++ b/funcs.sh
@@ -81,4 +81,11 @@ function datetime_to_epoch_secs {
   echo $(date --date "$datetime" +'%s')
 }
 
+function indicate_startup_done_if_needed {
+  if [[ "$PIA_WRITE_STARTUP_DONE_COMPLETED" != "true" ]] && [[ -n "$PIA_WRITE_STARTUP_DONE_FILE" ]]; then
+    echo "startup done" > "$PIA_WRITE_STARTUP_DONE_FILE"
+    export PIA_WRITE_STARTUP_DONE_COMPLETED=true
+  fi
+}
+
 set +a

--- a/piavpn-manual.service
+++ b/piavpn-manual.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=PIA vpn
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Type=forking
+Environment="PIA_AUTH_FILE=$AUTH_FILE"
+Environment="PIA_DNS=true"
+Environment="PIA_AUTOCONNECT=openvpn_udp_standard"
+Environment="PIA_PF=false"
+Environment="PIA_REGION=$REGION"
+WorkingDirectory=$INSTALL_LOCATION
+ExecStart=$INSTALL_LOCATION/systemd_launcher.sh
+PIDFile=/opt/piavpn-manual/pia_pid
+TimeoutStartSec=330
+TimeoutStopSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/port_forwarding.sh
+++ b/port_forwarding.sh
@@ -147,6 +147,7 @@ while true; do
       fi
       pia_on_port_forward_has_run="true"
     fi
+    indicate_startup_done_if_needed
 
     # sleep 15 minutes
     sleep 900


### PR DESCRIPTION
## Features

* Can run as a systemd service
  * Instructions: copy *.service file to /etc/systemd/system then customize vars prefixed with $ (e.g. $VAR)

### Added Config

| ENV Var | Function |
|-------|------|
|```PIA_WRITE_STARTUP_DONE_FILE=path```|When startup has completed successfully message "startup done" will be written to the file in the var. Can be used to manage dependencies (i.e. to launch another program when this one has completed). It is particularly useful when using port forwarding, as normally it wouldn't be clear when we have started up as the port forwarding script runs forever.|
 